### PR TITLE
Update Nginx version and increase replicas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.ignoreLimitWarning": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.ignoreLimitWarning": true
+}

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "kubernetes_deployment" "nginx" {
   }
 
   spec {
-    replicas = 1
+    replicas = 2
 
     selector {
       match_labels = {
@@ -35,7 +35,7 @@ resource "kubernetes_deployment" "nginx" {
 
       spec {
         container {
-          image = "nginx:1.21.6"
+          image = "nginx:1.23.0"
           name  = "nginx"
 
           port {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,12 @@
+variable "minikube_ip" {}
+variable "minikube_ca_crt" {}
+variable "minikube_token" {}
+
 provider "kubernetes" {
   config_path = "/mnt/workspace/kubeconfig"
+  host                   = "https://${var.minikube_ip}:8443"
+  cluster_ca_certificate = base64decode(var.minikube_ca_crt)
+  token                  = var.minikube_token
 }
 
 resource "kubernetes_namespace" "demo" {
@@ -10,37 +17,22 @@ resource "kubernetes_namespace" "demo" {
 
 resource "kubernetes_deployment" "nginx" {
   metadata {
-    name = "nginx"
+    name      = "nginx"
     namespace = kubernetes_namespace.demo.metadata[0].name
-    labels = {
-      app = "nginx"
-    }
+    labels    = { app = "nginx" }
   }
 
   spec {
     replicas = 2
-
-    selector {
-      match_labels = {
-        app = "nginx"
-      }
-    }
+    selector { match_labels = { app = "nginx" } }
 
     template {
-      metadata {
-        labels = {
-          app = "nginx"
-        }
-      }
-
+      metadata { labels = { app = "nginx" } }
       spec {
         container {
           image = "nginx:1.23.0"
           name  = "nginx"
-
-          port {
-            container_port = 80
-          }
+          port { container_port = 80 }
         }
       }
     }
@@ -49,20 +41,16 @@ resource "kubernetes_deployment" "nginx" {
 
 resource "kubernetes_service" "nginx" {
   metadata {
-    name = "nginx"
+    name      = "nginx"
     namespace = kubernetes_namespace.demo.metadata[0].name
   }
 
   spec {
-    selector = {
-      app = kubernetes_deployment.nginx.metadata[0].labels.app
-    }
-
+    selector = { app = "nginx" }
     port {
       port        = 80
       target_port = 80
     }
-
     type = "NodePort"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ provider "kubernetes" {
   cluster_ca_certificate = filebase64("/mnt/workspace/ca.crt")
   token                  = var.minikube_token
 }
-
 resource "kubernetes_namespace" "demo" {
   metadata {
     name = "demo"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "kubernetes" {
-  config_path = "~/.kube/config"
+  config_path = "/mnt/workspace/kubeconfig"
 }
 
 resource "kubernetes_namespace" "demo" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,10 @@
 variable "minikube_ip" {}
-variable "minikube_ca_crt" {}
 variable "minikube_token" {}
 
 provider "kubernetes" {
   config_path = "/mnt/workspace/kubeconfig"
   host                   = "https://${var.minikube_ip}:8443"
-  cluster_ca_certificate = base64decode(var.minikube_ca_crt)
+  cluster_ca_certificate = filebase64("/mnt/workspace/ca.crt")
   token                  = var.minikube_token
 }
 


### PR DESCRIPTION
Update Nginx version and increase replicas

## Summary by Sourcery

Update the Nginx deployment to use version 1.23.0 and increase the number of replicas to 2.

Enhancements:
- Increase the number of Nginx replicas to 2.
- Update the Nginx image to version 1.23.0.