### PR TITLE
reduced EKS max nodes from 4 to 3

### DIFF
--- a/infra/eks/main.tf
+++ b/infra/eks/main.tf
@@ -46,7 +46,7 @@ module "eks" {
   eks_managed_node_groups = {
     main = {
       min_size     = 2
-      max_size     = 4
+      max_size     = 3
       desired_size = 2
       
       instance_types = ["t3.medium"]


### PR DESCRIPTION
max nodes were scaled down from 4 to 3 nodes

## Summary by Sourcery

Deployment:
- Reduce the maximum number of nodes in the EKS cluster from 4 to 3.