### PR TITLE
Feature branch revise K8s version to 1.31 and revise desired node sta…

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -65,7 +65,7 @@ module "eks" {
     capacity_type = "SPOT"
     min_size     = 2
     max_size     = 4
-    desired_size = 2
+    desired_size = 3
     }
   }
 

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_name" {
 
 variable "eks_version" {
 type = string
-default = "1.30"
+default = "1.31"
 description = "EKS version"
 }
 


### PR DESCRIPTION
…te to 3

## Summary by Sourcery

Update EKS cluster configuration to use Kubernetes version 1.31 and increase the desired node count to 3

Enhancements:
- Upgrade EKS cluster Kubernetes version from 1.30 to 1.31

Chores:
- Increase the desired number of nodes in the EKS node group from 2 to 3